### PR TITLE
Fix: Added temperature to Device v1 

### DIFF
--- a/__tests__/crossdomain/device.test.js
+++ b/__tests__/crossdomain/device.test.js
@@ -50,6 +50,11 @@ describe('Crossdomain - device v1', () => {
     expect(deviceStatus.schema.id).toBe('dtmi:digitaltwins:ngsi_ld:ontology:DeviceStatus;1')
   })
 
+  it('Component temperatureObserved v1 should be present as temperature', () => {
+    const { temperature } = deviceModelV1Model.contents
+    expect(temperature.schema.id).toBe('dtmi:digitaltwins:ngsi_ld:ontology:temperatureObserved;1')
+  })
+
   it('Component address v1 should be present', () => {
     const { address } = deviceModelV1Model.contents
     expect(address.schema.id).toBe('dtmi:digitaltwins:ngsi_ld:ontology:Address;1')

--- a/ontology/crossdomain/v1/device.json
+++ b/ontology/crossdomain/v1/device.json
@@ -1,7 +1,7 @@
 {
     "@id": "dtmi:digitaltwins:ngsi_ld:ontology:Device;1",
     "@type": "Interface",
-    "displayName": "Device",
+    "displayName": "Device v1",
     "contents": [
         {
             "@type": "Command",

--- a/ontology/crossdomain/v1/device.json
+++ b/ontology/crossdomain/v1/device.json
@@ -46,6 +46,11 @@
             "@type": "Component",
             "name": "address",
             "schema": "dtmi:digitaltwins:ngsi_ld:ontology:Address;1"
+        },
+        {
+            "@type": "Component",
+            "name": "temperature",
+            "schema": "dtmi:digitaltwins:ngsi_ld:ontology:temperatureObserved;1"
         }
     ],
     "@context": [

--- a/ontology/crossdomain/v2/device.json
+++ b/ontology/crossdomain/v2/device.json
@@ -1,7 +1,7 @@
 {
     "@id": "dtmi:digitaltwins:ngsi_ld:ontology:Device;2",
     "@type": "Interface",
-    "displayName": "Device",
+    "displayName": "Device v2",
     "extends": "dtmi:digitaltwins:ngsi_ld:ontology:Device;1",
     "contents": [
         {


### PR DESCRIPTION
### Main Changes
- Added version reference for devices `Device v1` and `Device v2` (9ccf64b)
- Added Temperature to `Device v1` (96022be)



### Evolution

#### Before
![Captura de Pantalla 2023-02-07 a las 15 47 27](https://user-images.githubusercontent.com/5110813/218258137-7d867178-2373-4e9d-8f18-33e4ba42c6cf.png)


#### After
<img width="1782" alt="Captura de Pantalla 2023-02-11 a las 13 29 13" src="https://user-images.githubusercontent.com/5110813/218258129-b1594cd3-3c28-4700-9cea-41115f75898a.png">





### Changelog

- 9ccf64b chore: added version reference in DisplayName for devices by @UlisesGascon
- 96022be feat: added temperatureObserved component in device v1 by @UlisesGascon


